### PR TITLE
feat: Allow activities without start times

### DIFF
--- a/example/activities.txt
+++ b/example/activities.txt
@@ -11,3 +11,13 @@
 5 0 @sleep
 0 10 @calls @1
 
+# Example of timeless activities
+2022-08-15
+0 45 Morning email check @work
+1 30 Project planning @work @projectX
+0 20 Quick break @misc
+
+2022-08-15 14:00
+# Followed by timed activities on the same day
+2 0 Focused work session @work @projectX
+1 0 Meeting @work @team


### PR DESCRIPTION
This change introduces the ability to log activities that only have a date and a duration, without a specific start time. These are useful for accounting for work done at unspecified times during a day.

Modifications include:
- Enhanced date parsing to recognize 'YYYY-MM-DD' as a header for timeless activities, distinct from 'YYYY-MM-DD HH:MM' timed entries.
- Updated parsing logic (`tokens_from_timed_lpr`, `parse_activities`) to correctly assign a nominal start time (midnight of the header date) to timeless activities and ensure their durations are included in summaries without interfering with the time calculations of adjacent timed activities.
- Added new tests to cover various scenarios of timed and timeless activity logging.
- Updated example input file to demonstrate the new format.